### PR TITLE
Add gitignore and publish action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish package
+on:
+  push:
+    tags:
+    - 'v*'
+jobs:
+  create-release:
+    name: Create new release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish
+        uses: toitlang/pkg-publish@v1.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.packages/


### PR DESCRIPTION
The action will automatically publish the package to the Toit registry when a Github release is done or a tag (starting with "v") is added.